### PR TITLE
JHipster fails to auto-create caches when using EhCache

### DIFF
--- a/fullstack/pom.xml
+++ b/fullstack/pom.xml
@@ -388,6 +388,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.stormpath.spring</groupId>
+            <artifactId>stormpath-spring-security-webmvc-spring-boot-starter</artifactId>
+            <version>1.1.2</version>
+        </dependency>
         <!-- jhipster-needle-maven-add-dependency -->
     </dependencies>
     <build>

--- a/fullstack/src/main/java/org/terracotta/demo/config/SecurityConfiguration.java
+++ b/fullstack/src/main/java/org/terracotta/demo/config/SecurityConfiguration.java
@@ -22,6 +22,8 @@ import org.springframework.security.web.csrf.CsrfFilter;
 
 import javax.inject.Inject;
 
+import static com.stormpath.spring.config.StormpathWebSecurityConfigurer.stormpath;
+
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
@@ -75,7 +77,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http
+        http.apply(stormpath()).and()
             .csrf()
         .and()
             .addFilterAfter(new CsrfCookieGeneratorFilter(), CsrfFilter.class)

--- a/fullstack/src/main/resources/ehcache.xml
+++ b/fullstack/src/main/resources/ehcache.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="http://www.ehcache.org/v3">
+<config
+    xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+    xmlns='http://www.ehcache.org/v3'
+    xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+    xsi:schemaLocation="
+        http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
+        http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+
+    <service>
+        <jsr107:defaults default-template="simple"/>
+    </service>
 
     <cache-template name="simple">
         <expiry>
@@ -7,21 +17,5 @@
         </expiry>
         <heap>100</heap>
     </cache-template>
-
-    <cache alias="org.terracotta.demo.domain.User" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.Authority" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.User.authorities" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.PersistentToken" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.User.persistentTokens" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.PersistentAuditEvent" uses-template="simple"/>
-
-    <cache alias="org.terracotta.demo.domain.Actor" uses-template="simple"/>
-
-    <cache alias="weatherReports" uses-template="simple"/>
 
 </config>


### PR DESCRIPTION
This is a PR to show the behavior we see in JHipster after integrating Stormpath. Stormpath uses a [SpringCacheManager](https://github.com/stormpath/stormpath-sdk-java/blob/master/extensions/spring/stormpath-spring/src/main/java/com/stormpath/spring/cache/SpringCacheManager.java) implementation that wraps `org.springframework.cache.Cache`. It's pretty simple, so it's weird that caches aren't auto-created. When we use the Hazelcast option in Spring Boot, caches are auto-created when we fetch them by name.

To reproduce the issue, you'll likely need to signup for Stormpath at https://api.stormpath.com. Then download an `apiKey.properties` file from the Admin UI and put it at `~/.stormpath/apiKey.properties`. Our [Spring Boot Quickstart](https://docs.stormpath.com/java/spring-boot-web/quickstart.html) has a more detailed explanation.

See https://github.com/stormpath/stormpath-sdk-java/issues/1024 for more information.

DON'T MERGE this PR - I just created it to show the issue we're experiencing.

